### PR TITLE
Use CHANGES file date instead of build date

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,7 +3,7 @@ CC=cc
 
 all: src/Makefile.in
 	mkdir -p bin/@GAPARCH@;
-	sed -e "s/@DATE@/`date`/g" src/Makefile.in >src/Makefile
+	sed -e "s/@DATE@/`date -u -r CHANGES`/g" src/Makefile.in >src/Makefile
 	(cd src; make)
 	mv src/ace bin/@GAPARCH@/ace
 


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good

Alternative patches could use `$SOURCE_DATE_EPOCH` as described in
https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal#Bash_.2F_POSIX_shell