### PR TITLE
Drop build date from binary

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -3,7 +3,7 @@ CC=cc
 
 all: src/Makefile.in
 	mkdir -p bin/@GAPARCH@;
-	sed -e "s/@DATE@/`date`/g" src/Makefile.in >src/Makefile
+	sed -e "" src/Makefile.in >src/Makefile
 	(cd src; make)
 	mv src/ace bin/@GAPARCH@/ace
 

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -30,7 +30,7 @@ Persons := [
     IsAuthor      := true,
     IsMaintainer  := false,
     Email         := "hulpke@math.colostate.edu",
-    WWWHome       := "http://www.math.colostate.edu/~hulpke",
+    WWWHome       := "https://www.math.colostate.edu/~hulpke",
     PostalAddress := Concatenation( [
                        "Alexander Hulpke\n",
                        "Department of Mathematics\n",

--- a/README
+++ b/README
@@ -39,11 +39,11 @@ the previous version (4.1) of ACE.
 You can download  `ace-XXX.tar.gz'  (where  `XXX'  is  the  package  version
 number) from the home page for the ACE package
 
-http://gap-packages.github.io/ace/
+https://gap-packages.github.io/ace/
 
 or via the GAP web site
 
-http://www.gap-system.org/Packages/ace.html
+https://www.gap-system.org/Packages/ace.html
 
 If you prefer .zip or tar.bz2 to tar.gz archives, substitute the appropriate
 suffix in the  above paths.

--- a/doc/install.tex
+++ b/doc/install.tex
@@ -111,7 +111,7 @@ gap> LoadPackage("ace");
 ---------------------------------------------------------------------------
 Loading    ACE (Advanced Coset Enumerator) 5.2
 GAP code by Greg Gamble <Greg.Gamble@uwa.edu.au> (address for correspondence)
-       Alexander Hulpke (http://www.math.colostate.edu/~hulpke)
+       Alexander Hulpke (https://www.math.colostate.edu/~hulpke)
            [uses ACE binary (C code program) version: 3.001]
 C code by  George Havas (http://staff.itee.uq.edu.au/havas)
            Colin Ramsay <cram@itee.uq.edu.au>

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -83,13 +83,7 @@ SRC0  = coinc.c enum.c util0.c
 SRC0A = enum00.c enum01.c enum02.c
 
 # Level 2 (interactive interface)
-#
-# Note the setting of (THE)DATE, so that we can record the time/date of
-# this build in the executable (usage: "fprint(fop, "%s\n", DATE);")
-
-THEDATE = "'@DATE@'"
 
 ace: al2.h $(SRC2) al1.h $(SRC1) al0.h $(SRC0) $(SRC0A)
-	$(CC) $(FLAGS) $(EXTRA_CFLAGS) $(CFLAGS) -DDATE="\"$(THEDATE)\"" -o ace \
+	$(CC) $(FLAGS) $(EXTRA_CFLAGS) $(CFLAGS) -o ace \
 		$(SRC2) $(SRC1) $(SRC0) $(LDFLAGS)
-

--- a/src/util2.c
+++ b/src/util2.c
@@ -329,11 +329,7 @@ void al2_dump(Logic allofit)
 
 void al2_opt(void)
   {
-#ifdef DATE
-  fprintf(fop, "%s executable built:\n  %s\n", ACE_VER, DATE);
-#else
-  fprintf(fop, "%s executable built: ??\n", ACE_VER);
-#endif
+  fprintf(fop, "%s executable\n", ACE_VER);
 
   fprintf(fop, "Level 0 options:\n");
 #ifdef AL0_STAT


### PR DESCRIPTION
This simplifies the code and enables reproducible builds.
See https://reproducible-builds.org/ for why this is good.

Alternative approach is #15

This PR was done while working on reproducible builds for openSUSE.