### PR TITLE
Initialize two local variables

### DIFF
--- a/src/enum.c
+++ b/src/enum.c
@@ -264,7 +264,7 @@ int al0_apply(int cos, int *beg, int *end, Logic defn, Logic save)
 
 static int al0_rl(int first, int last, Logic saved)
   {
-  int row,rel,i,ii,j,k,l;
+  int row,rel,i,ii,j,k,l = 0;
   int *pj, *pk, *fwd, *bwd;
   int ifront, iback;
 
@@ -359,7 +359,7 @@ static int al0_rl(int first, int last, Logic saved)
 
 static int al0_cl(int first, int last, Logic saved)
   {
-  int row,col,beg,end,i,j,ji,k;
+  int row,col,beg,end,i,j,ji,k = 0;
   int *pj, *pk, *fwd, *bwd;
   int ifront, iback;
 


### PR DESCRIPTION
GCC 12 issues these warnings:
```
enum.c: In function 'al0_cl':
enum.c:394:6: warning: 'k' may be used uninitialized [-Wmaybe-uninitialized]
  394 |   if (k == 0)
      |      ^
enum.c:362:30: note: 'k' was declared here
  362 |   int row,col,beg,end,i,j,ji,k;
      |                              ^
enum.c: In function 'al0_rl.constprop.0':
enum.c:295:6: warning: 'l' may be used uninitialized [-Wmaybe-uninitialized]
  295 |   if (l == 0)
      |      ^
enum.c:267:24: note: 'l' was declared here
  267 |   int row,rel,i,ii,j,k,l;
      |                        ^
```

For either variable to actually be used uninitialized would require that pj > pk after the first for loop exits.  Perhaps that is impossible.  I don't understand this code well enough to tell.  This PR takes the conservative route and initializes the variables so that nobody has to figure that out.