### PR TITLE
Mark functions that do not return in a standard way

### DIFF
--- a/src/al2.h
+++ b/src/al2.h
@@ -23,6 +23,14 @@ application in the form of a stand alone, interactive interface.
 
 #include <setjmp.h>	/* Needed for setjmp/longjmp jmp_buf type */
 
+#if __STDC_VERSION__ >= 202311L
+#define Noreturn [[noreturn]]
+#elif __STDC_VERSION__ >= 201112L
+#define Noreturn _Noreturn
+#else
+#define Noreturn
+#endif
+
 extern jmp_buf env;	/* Environment for error-recovery jump */
 
 	/******************************************************************
@@ -82,13 +90,9 @@ extern int intcnt, intarr[32];
 void  al2_init(void);
 char *al2_strdup(char*);
 int   al2_outlen(int);
-void  al2_continue(char*);
-#ifdef __GNUC__
-void  al2_restart(char*) __attribute__ ((noreturn));
-#else
-void  al2_restart(char*);
-#endif
-void  al2_abort(char*);
+Noreturn void  al2_continue(char*);
+Noreturn void  al2_restart(char*);
+Noreturn void  al2_abort(char*);
 
 void al2_aip(char*);
 void al2_aop(char*);


### PR DESCRIPTION
All 3 of `al2_continue`, `al2_restart`, and `al2_abort` do not return in the normal way (they use longjmp to exit).  Instead of using a gcc-specific attribute to indicate this property, this change uses `_Noreturn` for C11 compilers and `[[noreturn]]` for C23 compilers, which has the benefit for working for non-GCC compilers as well.

Note that GCC added support for `_Noreturn` in GCC 4.7.  Even RHEL 7, one of the older enterprise Linuxes, currently ships GCC 4.8.  It is not easy in 2022 to find a GCC so old that it does not support C11.
