### PR TITLE
Do not use -ansi, which limits the C standard

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,13 +16,12 @@
 #
 # -Wall     : print all warnings
 # -pedantic : be bloody picky
-# -ansi     : enforce ANSI compliance
 # -O2/3     : optimise quite a bit / a lot
 # -g        : for xxgdb debugger
 # -pg       : profiling info for gprof
 ########################################################################
 CC ?= gcc
-EXTRA_CFLAGS ?= -Wall -pedantic -ansi -O2
+EXTRA_CFLAGS ?= -Wall -pedantic -O2
 
 ########################################################################
 # SunOS 5.5 boxes with `native' cc.


### PR DESCRIPTION
The `-ansi` flag used to be good, as it allowed using ANSI C instead of K&R C.  For some years now, though, `-ansi` has been a limitation, telling the compiler not to use a C standard newer than C90.  This makes a previous PR, https://github.com/gap-packages/ace/pull/31, not useful since it depends on compilers with default C standards later than C90.